### PR TITLE
Updated readme on berkshelf command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ http://downloads.vagrantup.com/
 Berkshelf http://berkshelf.com/ is awesome, and makes the Chef provisioning in Vagrant and elsewhere a breeze by downloading the dependent cookbooks.  From a command prompt run:
 
 ```
-vagrant plugin install berkshelf-vagrant
+vagrant plugin install vagrant-berkshelf
 ```
 
 ## Place this repo's files


### PR DESCRIPTION
Berkshalf vagrant variant has been renamed by its maintainer at
https://github.com/RiotGames/vagrant-berkshelf

User using the old command will face the following error when
executing "vagrant up":

Vagrant:
- Unknown configuration section 'berkshelf'.
