### PR TITLE
update so that only .meteor/local is tracked

### DIFF
--- a/cookbooks/meteor_windows/recipes/default.rb
+++ b/cookbooks/meteor_windows/recipes/default.rb
@@ -58,26 +58,26 @@ apps.each do |app|
   Chef::Log.info("Creating Meteor App: #{app}")
 
   # Create Destination folder for the database symlink mount of the created app
-  directory "#{node['meteor_windows']['home_directory']}/#{app}" do
+  directory "#{node['meteor_windows']['home_directory']}/#{app}/.meteor/local" do
     action :create
     recursive true
     owner node['meteor_windows']['owner']
     group node['meteor_windows']['group']
   end
 
-  # Create the Meteor App, move the hidden .meteor directory, and leave a breadcrumb to prevent recreating the app each run
+  # Create the Meteor App, move the hidden .meteor/local directory, and leave a breadcrumb to prevent recreating the app each run
   bash "meteor_create_#{app}" do
     cwd node['meteor_windows']['sync_directory']
     code <<-EOF
     #{node['meteor_windows']['meteor_command']} create #{app}
-    mv #{node['meteor_windows']['sync_directory']}/#{app}/.meteor #{node['meteor_windows']['home_directory']}/#{app}/.meteor
+    mv #{node['meteor_windows']['sync_directory']}/#{app}/.meteor/local #{node['meteor_windows']['home_directory']}/#{app}/.meteor/local
     touch #{Chef::Config[:file_cache_path]}/meteor_#{app}_created_by_chef
     EOF
     not_if { ::File.exists?("#{Chef::Config[:file_cache_path]}/meteor_#{app}_created_by_chef") }
   end
 
-  # Re-Create the .meteor directory in order to map the symlink
-  directory "#{node['meteor_windows']['sync_directory']}/#{app}/.meteor" do
+  # Re-Create the .meteor/local directory in order to map the symlink
+  directory "#{node['meteor_windows']['sync_directory']}/#{app}/.meteor/local" do
     action :create
     recursive true
     owner node['meteor_windows']['owner']
@@ -86,8 +86,8 @@ apps.each do |app|
 
   # Create a mount symlink from the sync directory to the home directory
   # This is required to move the Mongo DB location to a non-synced folder
-  mount "#{node['meteor_windows']['sync_directory']}/#{app}/.meteor" do
-    device "#{node['meteor_windows']['home_directory']}/#{app}/.meteor"
+  mount "#{node['meteor_windows']['sync_directory']}/#{app}/.meteor/local" do
+    device "#{node['meteor_windows']['home_directory']}/#{app}/.meteor/local"
     fstype "none"
     options "bind,rw"
     action [:mount]


### PR DESCRIPTION
I found when I wanted to add my project to git, I couldn't track the things in .meteor (such as .meteor/packages and .meteor/release) as they were in the vagrant home directory.

From reading around it seems that only .meteor/local needs to be mounted, where as the rest of .meteor can reside on the vagrant share.

This pull request implements that change.
